### PR TITLE
Feature/data min freq

### DIFF
--- a/soundbay/conf/data/Manatees.yaml
+++ b/soundbay/conf/data/Manatees.yaml
@@ -6,6 +6,7 @@ data:
   sample_rate: 96000
   data_sample_rate: 96000
   max_freq: 44100
+  min_freq_spectrogram: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/Manatees.yaml
+++ b/soundbay/conf/data/Manatees.yaml
@@ -6,7 +6,7 @@ data:
   sample_rate: 96000
   data_sample_rate: 96000
   max_freq: 44100
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/audio_MNIST.yaml
+++ b/soundbay/conf/data/audio_MNIST.yaml
@@ -5,7 +5,7 @@ data:
   sample_rate: 8000
   data_sample_rate: 8000
   max_freq: 4000
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 256
   hop_length: 64
   train_dataset:

--- a/soundbay/conf/data/audio_MNIST.yaml
+++ b/soundbay/conf/data/audio_MNIST.yaml
@@ -5,6 +5,7 @@ data:
   sample_rate: 8000
   data_sample_rate: 8000
   max_freq: 4000
+  min_freq_spectrogram: 0
   n_fft: 256
   hop_length: 64
   train_dataset:

--- a/soundbay/conf/data/defaults.yaml
+++ b/soundbay/conf/data/defaults.yaml
@@ -6,7 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 8000
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/defaults.yaml
+++ b/soundbay/conf/data/defaults.yaml
@@ -6,7 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 8000
-  min_freq_spectrogram: 1000
+  min_freq_spectrogram: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/defaults.yaml
+++ b/soundbay/conf/data/defaults.yaml
@@ -6,6 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 8000
+  min_freq_spectrogram: 1000
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/defaults_multiclass.yaml
+++ b/soundbay/conf/data/defaults_multiclass.yaml
@@ -6,6 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 8000
+  min_freq_spectrogram: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/defaults_multiclass.yaml
+++ b/soundbay/conf/data/defaults_multiclass.yaml
@@ -6,7 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 8000
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:
@@ -18,7 +18,6 @@ data:
     augmentations: ${_augmentations}
     preprocessors: ${_preprocessors}
     seq_length: 1 
-    len_buffer: 0.1
     margin_ratio: 0.5
     data_sample_rate: ${data.data_sample_rate}
     sample_rate: ${data.sample_rate}
@@ -32,7 +31,6 @@ data:
     augmentations: null
     preprocessors: ${_preprocessors}
     seq_length: 1
-    len_buffer: 0.1
     margin_ratio: 0
     data_sample_rate: ${data.data_sample_rate}
     sample_rate: ${data.sample_rate}

--- a/soundbay/conf/data/icml2013.yaml
+++ b/soundbay/conf/data/icml2013.yaml
@@ -6,6 +6,7 @@ data:
   sample_rate: 2000
   data_sample_rate: 2000
   max_freq: 1000
+  min_freq_spectrogram: 0
   n_fft: 256
   hop_length: 64
   train_dataset:

--- a/soundbay/conf/data/icml2013.yaml
+++ b/soundbay/conf/data/icml2013.yaml
@@ -6,7 +6,7 @@ data:
   sample_rate: 2000
   data_sample_rate: 2000
   max_freq: 1000
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 256
   hop_length: 64
   train_dataset:
@@ -18,7 +18,6 @@ data:
     augmentations: ${_augmentations}
     preprocessors: ${_preprocessors}
     seq_length: 1.5
-    len_buffer: 0.1
     margin_ratio: 0
     data_sample_rate: ${data.data_sample_rate}
     sample_rate: ${data.sample_rate}
@@ -32,7 +31,6 @@ data:
     augmentations: null
     preprocessors: ${_preprocessors}
     seq_length: 1.5
-    len_buffer: 0.1
     margin_ratio: 0
     data_sample_rate: ${data.data_sample_rate}
     sample_rate: ${data.sample_rate}

--- a/soundbay/conf/data/mozambique_2018.yaml
+++ b/soundbay/conf/data/mozambique_2018.yaml
@@ -6,7 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 1500
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/mozambique_2018.yaml
+++ b/soundbay/conf/data/mozambique_2018.yaml
@@ -6,6 +6,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 44100
   max_freq: 1500
+  min_freq_spectrogram: 0
   n_fft: 1024
   hop_length: 256
   train_dataset:

--- a/soundbay/conf/data/orcasound.yaml
+++ b/soundbay/conf/data/orcasound.yaml
@@ -5,6 +5,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 20000
   max_freq: 1000
+  min_freq_spectrogram: 0
   n_fft: 256
   hop_length: 64
   train_dataset:

--- a/soundbay/conf/data/orcasound.yaml
+++ b/soundbay/conf/data/orcasound.yaml
@@ -5,7 +5,7 @@ data:
   sample_rate: 16000
   data_sample_rate: 20000
   max_freq: 1000
-  min_freq_spectrogram: 0
+  min_freq_filtering: 0
   n_fft: 256
   hop_length: 64
   train_dataset:

--- a/soundbay/conf/preprocessors/_preprocessors.yaml
+++ b/soundbay/conf/preprocessors/_preprocessors.yaml
@@ -4,6 +4,11 @@ _preprocessors:
     _target_: torchaudio.transforms.Spectrogram
     n_fft: ${data.n_fft}
     hop_length: ${data.hop_length}
+  min_freq:
+    _target_: soundbay.data.MinFreqSpectrogram
+    min_freq_spectrogram: ${data.min_freq_spectrogram}
+    sample_rate: ${data.sample_rate}
+    n_fft: ${data.n_fft}
   amplitude_2_db:
     _target_: torchaudio.transforms.AmplitudeToDB
   peak_norm:

--- a/soundbay/conf/preprocessors/_preprocessors.yaml
+++ b/soundbay/conf/preprocessors/_preprocessors.yaml
@@ -4,9 +4,9 @@ _preprocessors:
     _target_: torchaudio.transforms.Spectrogram
     n_fft: ${data.n_fft}
     hop_length: ${data.hop_length}
-  min_freq:
-    _target_: soundbay.data.MinFreqSpectrogram
-    min_freq_spectrogram: ${data.min_freq_spectrogram}
+  min_freq_filtering:
+    _target_: soundbay.data.MinFreqFiltering
+    min_freq_filtering: ${data.min_freq_filtering}
     sample_rate: ${data.sample_rate}
   amplitude_2_db:
     _target_: torchaudio.transforms.AmplitudeToDB

--- a/soundbay/conf/preprocessors/_preprocessors.yaml
+++ b/soundbay/conf/preprocessors/_preprocessors.yaml
@@ -8,7 +8,6 @@ _preprocessors:
     _target_: soundbay.data.MinFreqSpectrogram
     min_freq_spectrogram: ${data.min_freq_spectrogram}
     sample_rate: ${data.sample_rate}
-    n_fft: ${data.n_fft}
   amplitude_2_db:
     _target_: torchaudio.transforms.AmplitudeToDB
   peak_norm:

--- a/soundbay/conf/preprocessors/_preprocessors_unit.yaml
+++ b/soundbay/conf/preprocessors/_preprocessors_unit.yaml
@@ -4,6 +4,10 @@ _preprocessors:
     _target_: torchaudio.transforms.Spectrogram
     n_fft: 1024
     hop_length: 256
+  min_freq_filtering:
+    _target_: soundbay.data.MinFreqFiltering
+    min_freq_filtering: ${data.min_freq_filtering}
+    sample_rate: ${data.sample_rate}
   amplitude_2_db:
     _target_: torchaudio.transforms.AmplitudeToDB
   unit_norm:

--- a/soundbay/data.py
+++ b/soundbay/data.py
@@ -309,17 +309,29 @@ class PeakNormalize:
         return (sample - sample.min()) / (sample.max() - sample.min())
 
 
-class MinFreqSpectrogram:
-    """Cut the spectrogram frequency axis to make it start from min_freq"""
-    def __init__(self, min_freq_spectrogram, sample_rate):
-        self.min_freq_spectrogram = min_freq_spectrogram
+class MinFreqFiltering:
+    """Cut the spectrogram frequency axis to make it start from min_freq
+    ***Note: In case a MaxFreqFiltering is implemented, the max_freq should be greater than min_freq***
+
+    input:
+        min_freq_filtering - int
+        sample_rate - int
+
+    output:
+        spectrogram - pytorch tensor (3-D array)
+    """
+
+    def __init__(self, min_freq_filtering, sample_rate):
+        self.min_freq_filtering = min_freq_filtering
         self.sample_rate = sample_rate
 
     def edit_spectrogram_axis(self, sample):
+        if self.min_freq_filtering > self.sample_rate / 2 or self.min_freq_filtering < 0:
+            raise ValueError("min_freq_filtering should be greater than 0, and smaller than sample_rate/2")
         max_freq_in_spectrogram = self.sample_rate / 2
-        min_value = sample.size(dim=1) * self.min_freq_spectrogram / max_freq_in_spectrogram
+        min_value = sample.size(dim=1) * self.min_freq_filtering / max_freq_in_spectrogram
         min_value = int(np.floor(min_value))
-        sample = sample[:, min_value:, :]
+        sample = sample[:, :-min_value, :]
 
         return sample
 

--- a/soundbay/data.py
+++ b/soundbay/data.py
@@ -331,7 +331,7 @@ class MinFreqFiltering:
         max_freq_in_spectrogram = self.sample_rate / 2
         min_value = sample.size(dim=1) * self.min_freq_filtering / max_freq_in_spectrogram
         min_value = int(np.floor(min_value))
-        sample = sample[:, :-min_value, :]
+        sample = sample[:, min_value:, :]
 
         return sample
 

--- a/soundbay/data.py
+++ b/soundbay/data.py
@@ -16,7 +16,7 @@ from torch.utils.data import Dataset
 from torchvision import transforms
 
 from soundbay.data_augmentation import ChainedAugmentations
-
+import matplotlib.pyplot as plt
 
 class BaseDataset(Dataset):
     '''
@@ -292,17 +292,16 @@ class PeakNormalize:
 
 class MinFreqSpectrogram:
     """Cut the spectrogram frequency axis to make it start from min_freq"""
-    def __init__(self, min_freq_spectrogram, sample_rate, n_fft):
+    def __init__(self, min_freq_spectrogram, sample_rate):
         self.min_freq_spectrogram = min_freq_spectrogram
         self.sample_rate = sample_rate
-        self.n_fft = n_fft #TODO probably remove? redundant with current implementation
 
     def edit_spectrogram_axis(self, sample):
-
         max_freq_in_spectrogram = self.sample_rate / 2
         min_value = sample.size(dim=1) * self.min_freq_spectrogram / max_freq_in_spectrogram
-        min_value = np.floor(min_value)
+        min_value = int(np.floor(min_value))
         sample = sample[:, min_value:, :]
+
         return sample
 
     def __call__(self, sample):


### PR DESCRIPTION
implemented minimal frequency cutoff for spectrogram - takes place within the preprocessing, as part of _preprocessors.yaml config (after spectrogram, before amplitude_2_db)
the argument is called min_freq_spectrogram and is input through data config.
updated all data training configs with min_freq_spectrogram=0 - change as required.