### PR TITLE
hotfix changes

### DIFF
--- a/soundbay/data.py
+++ b/soundbay/data.py
@@ -52,6 +52,9 @@ class BaseDataset(Dataset):
         assert (0 <= margin_ratio) and (1 >= margin_ratio)
         self.margin_ratio = margin_ratio
         self.items_per_classes = np.unique(self.metadata['label'], return_counts=True)[1]
+        weights = 1 / self.items_per_classes
+        self.samples_weight = np.array([weights[t] for t in self.metadata['label'] ])
+
 
     @staticmethod
     def _update_metadata_by_mode(metadata, mode, split_metadata_by_label):

--- a/soundbay/train.py
+++ b/soundbay/train.py
@@ -83,7 +83,7 @@ def modeling(
 
     # Define dataloader for training and validation datasets as well as optimizers arguments
     if equalize_data:
-        sampler = WeightedRandomSampler(1/train_dataset.items_per_classes, len(train_dataset) ) 
+        sampler = WeightedRandomSampler(train_dataset.samples_weight, len(train_dataset)) 
     else:
         sampler = None
     train_dataloader = DataLoader(


### PR DESCRIPTION
Bug using random sampler in a problematic way.
in a nutshell: `WeightedRandomSampler` uses `torch.multinomial` .
This class assigns weights to *each sample* and so it actually will choose the same samples (The first and second with the probabilities we assigned).
What needed to be done is to assign to *each* sample the prior probability.
https://discuss.pytorch.org/t/how-to-handle-imbalanced-classes/11264