### PR TITLE
Fix bug of bg creation function

### DIFF
--- a/soundbay/utils/metadata_processing.py
+++ b/soundbay/utils/metadata_processing.py
@@ -192,6 +192,8 @@ def bg_from_non_overlap_calls(df: pd.DataFrame):
     Returns: a dataframe with bg calls taken from the gaps of the positive calls in a given file
     """
     bg_calls = []
+    # Sort by begin time to avoid negative call lengths and erroneously reverse times
+    df = df.sort_values(by='begin_time', ascending=True)
     for _, df_per_file in df.groupby(by='filename'):
         # df_per_file is already sorted by begin_time!
         df_per_file_copy = df_per_file.iloc[1:].copy()


### PR DESCRIPTION
This input (`dict` casted `pd.DataFrame`)
```
{'filename': {6: '7205.230415030015.wav', 7: '7205.230415030015.wav'},
 'call_length': {6: 0.30160000000614673, 7: 0.21100000001024455},
 'begin_time': {6: 120.6042, 7: 67.7566},
 'end_time': {6: 120.90580000000615, 7: 67.96760000001025},
 'label': {6: 1, 7: 1},
 'annotations_filename': {6: 'FlumeL_m_23.04.11.Sounds.selections_DV.txt',
  7: 'FlumeL_m_23.04.11.Sounds.selections_DV.txt'},
 's3_path': {6: 's3://deepvoice-user-uploads/shayetudor@gmail.com/dropbox/cods/FlumeL_m_23.04.11-23.04.23_wav shaye tudor',
  7: 's3://deepvoice-user-uploads/shayetudor@gmail.com/dropbox/cods/FlumeL_m_23.04.11-23.04.23_wav shaye tudor'}}
```
to `bg_from_non_overlap_calls` causes negative `call length` and wrong `begin_time` and `end_time`.
```
{'filename': {0: '7205.230415030015.wav',
  1: '7205.230415030015.wav',
  2: '7205.230415030015.wav'},
 'call_length': {0: -53.14920000000615,
  1: 0.30160000000614673,
  2: 0.21100000001024455},
 'begin_time': {0: 120.90580000000615, 1: 120.6042, 2: 67.7566},
 'end_time': {0: 67.7566, 1: 120.90580000000615, 2: 67.96760000001025},
 'label': {0: 0, 1: 1, 2: 1},
 'annotations_filename': {0: 'FlumeL_m_23.04.11.Sounds.selections_DV.txt',
  1: 'FlumeL_m_23.04.11.Sounds.selections_DV.txt',
  2: 'FlumeL_m_23.04.11.Sounds.selections_DV.txt'},
 's3_path': {0: 's3://deepvoice-user-uploads/shayetudor@gmail.com/dropbox/cods/FlumeL_m_23.04.11-23.04.23_wav shaye tudor',
  1: 's3://deepvoice-user-uploads/shayetudor@gmail.com/dropbox/cods/FlumeL_m_23.04.11-23.04.23_wav shaye tudor',
  2: 's3://deepvoice-user-uploads/shayetudor@gmail.com/dropbox/cods/FlumeL_m_23.04.11-23.04.23_wav shaye tudor'}}
```


The PR fixes this issue.