### PR TITLE
Update ci_action.yml

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -6,7 +6,7 @@ jobs:
 
   ci-test:
     if: ${{ github.event.label.name == 'ci-test' }}
-    runs-on: ubuntu-20.04 
+    runs-on: ubuntu-22.04 
     steps:
       - name: Checkout 
         uses: actions/checkout@v3


### PR DESCRIPTION
re this:

> We are beginning the process of closing down the Ubuntu 20 hosted runner image, following our N-1 OS [support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This image will be fully retired by April 1, 2025. We recommend updating workflows to use ubuntu-22.04, or ubuntu-24.04.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down