### PR TITLE
Feature/raven export wrapper

### DIFF
--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -4,6 +4,86 @@ Raven Intelligence Export Module
 This module provides utilities to export soundbay models to Raven Intelligence format.
 It wraps trained models with their preprocessing pipeline to create standalone models
 that accept raw audio input, compatible with Raven Intelligence's expected interface.
+
+Raven Intelligence is a bioacoustics analysis tool from Cornell Lab of Ornithology that
+uses DJL (Deep Java Library) to run ML models for automated sound detection.
+
+=========================================================================================
+USAGE EXAMPLES
+=========================================================================================
+
+1. COMMAND LINE - Export a soundbay checkpoint to Raven format:
+   -------------------------------------------------------------------------
+   python scripts/raven_export.py /path/to/checkpoint/best.pth \\
+       --output-dir ~/Raven\ Workbench/Raven\ Intelligence/Models/ \\
+       --name My_Detector
+
+   This requires args.yaml to be in the same directory as the checkpoint.
+
+2. PYTHON API - Export from soundbay checkpoint:
+   -------------------------------------------------------------------------
+   from scripts.raven_export import create_raven_model_package
+
+   create_raven_model_package(
+       checkpoint_path='/path/to/checkpoint/best.pth',
+       output_dir='~/Raven Workbench/Raven Intelligence/Models/',
+       model_name='My_Detector',
+       export_format='torchscript',  # recommended; 'onnx' also available
+   )
+
+3. PYTHON API - Package an existing TorchScript model:
+   -------------------------------------------------------------------------
+   from scripts.raven_export import create_raven_model_package_from_torchscript
+
+   create_raven_model_package_from_torchscript(
+       torchscript_path='/path/to/model.pt',
+       output_dir='~/Raven Workbench/Raven Intelligence/Models/',
+       model_name='Whale_Detector',
+       label_names=['Noise', 'HUWH', 'RIWH'],
+       sample_rate=2000,   # Hz - input audio sample rate
+       seq_length=4.0,     # seconds - input audio duration
+   )
+
+=========================================================================================
+OUTPUT STRUCTURE
+=========================================================================================
+
+The export creates a .ravenmodel package with the following structure:
+
+    {output_dir}/
+    ├── {model_name}.ravenmodel    # JSON config file (describes model to Raven)
+    └── {model_name}/
+        ├── model.pt               # TorchScript model (or model.onnx)
+        └── labels.txt             # Class labels, one per line
+
+Copy both the .ravenmodel file AND the model directory to:
+    ~/Raven Workbench/Raven Intelligence/Models/
+
+Then restart Raven Intelligence and select the model for detection.
+
+=========================================================================================
+SUPPORTED MODEL ARCHITECTURES
+=========================================================================================
+
+Currently supports exporting these soundbay model types:
+- ResNet182D
+- Squeezenet2D
+
+For other architectures, use create_raven_model_package_from_torchscript() with a
+pre-exported TorchScript model that has preprocessing embedded.
+
+=========================================================================================
+NOTES
+=========================================================================================
+
+- TorchScript export is recommended over ONNX (STFT operations not supported in ONNX)
+- The wrapper embeds all preprocessing (resampling, MelSpectrogram, normalization)
+  so the exported model accepts raw audio and outputs class probabilities
+- Raven Intelligence uses DJL with PyTorch 2.5.1 - ensure version compatibility
+- Input tensor shape: (batch, samples) for models exported with this script
+- Output tensor shape: (batch, num_classes) with softmax probabilities
+
+=========================================================================================
 """
 
 import json

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -132,21 +132,37 @@ def _get_model_class(model_target: str):
 
 
 class PeakNormalizeModule(nn.Module):
-    """nn.Module version of PeakNormalize for export compatibility."""
+    """
+    nn.Module version of PeakNormalize for TorchScript export compatibility.
+
+    This is a re-implementation of soundbay.data.PeakNormalize as an nn.Module.
+    The original class uses __call__ which doesn't trace properly for TorchScript.
+
+    See: soundbay/data.py::PeakNormalize
+
+    IMPORTANT: Logic must match the original exactly to ensure consistent inference.
+    """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x_min = x.amin(dim=(-2, -1), keepdim=True)
-        x_max = x.amax(dim=(-2, -1), keepdim=True)
-        return (x - x_min) / (x_max - x_min + 1e-8)
+        # Match original: (sample - sample.min()) / (sample.max() - sample.min() + 1e-8)
+        return (x - x.min()) / (x.max() - x.min() + 1e-8)
 
 
 class UnitNormalizeModule(nn.Module):
-    """nn.Module version of UnitNormalize for export compatibility."""
+    """
+    nn.Module version of UnitNormalize for TorchScript export compatibility.
+
+    This is a re-implementation of soundbay.data.UnitNormalize as an nn.Module.
+    The original class uses __call__ which doesn't trace properly for TorchScript.
+
+    See: soundbay/data.py::UnitNormalize
+
+    IMPORTANT: Logic must match the original exactly to ensure consistent inference.
+    """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        mean = x.mean(dim=(-2, -1), keepdim=True)
-        std = x.std(dim=(-2, -1), keepdim=True)
-        return (x - mean) / (std + 1e-8)
+        # Match original: (sample - sample.mean()) / (sample.std() + 1e-8)
+        return (x - x.mean()) / (x.std() + 1e-8)
 
 
 class PreprocessingPipeline(nn.Module):

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -16,7 +16,14 @@ USAGE EXAMPLES
    -------------------------------------------------------------------------
    python scripts/raven_export.py /path/to/checkpoint/best.pth \\
        --output-dir ~/Raven\ Workbench/Raven\ Intelligence/Models/ \\
-       --name My_Detector
+       --name My_Detector \\
+       --format torchscript
+
+   Options:
+     --output-dir   Output directory for the model package (default: current dir)
+     --name         Model name (default: checkpoint directory name)
+     --format       Export format: 'torchscript' (default) or 'onnx'
+     --no-softmax   Do not apply softmax to outputs
 
    This requires args.yaml to be in the same directory as the checkpoint.
 
@@ -73,6 +80,13 @@ For other architectures, use create_raven_model_package_from_torchscript() with 
 pre-exported TorchScript model that has preprocessing embedded.
 
 =========================================================================================
+REQUIREMENTS
+=========================================================================================
+
+This script requires the `transformers` package to be installed (for soundbay.models import):
+    pip install transformers
+
+=========================================================================================
 NOTES
 =========================================================================================
 
@@ -80,7 +94,8 @@ NOTES
 - The wrapper embeds all preprocessing (resampling, MelSpectrogram, normalization)
   so the exported model accepts raw audio and outputs class probabilities
 - Raven Intelligence uses DJL with PyTorch 2.5.1 - ensure version compatibility
-- Input tensor shape: (batch, samples) for models exported with this script
+- Input tensor shape: (batch, samples) for models exported via create_raven_model_package
+- Input tensor shape: (batch, channels, samples) for pre-existing TorchScript models
 - Output tensor shape: (batch, num_classes) with softmax probabilities
 
 =========================================================================================

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -12,7 +12,7 @@ uses DJL (Deep Java Library) to run ML models for automated sound detection.
 USAGE EXAMPLES
 =========================================================================================
 
-1. COMMAND LINE - Export a soundbay checkpoint to Raven format:
+1. COMMAND LINE - Export a soundbay checkpoint to Raven format (RECOMMENDED):
    -------------------------------------------------------------------------
    python scripts/raven_export.py /path/to/checkpoint/best.pth \\
        --output-dir ~/Raven\ Workbench/Raven\ Intelligence/Models/ \\
@@ -24,15 +24,14 @@ USAGE EXAMPLES
      --name                      Model name (default: checkpoint directory name)
      --format                    Export format: 'torchscript' (default) or 'onnx'
      --no-softmax                Do not apply softmax to outputs (raw logits)
-     --compensate-for-sigmoid    Apply softmax + inverse-sigmoid (recommended, see below)
+     --compensate-for-sigmoid    Apply softmax + inverse-sigmoid (legacy workaround, see below)
 
    This requires args.yaml to be in the same directory as the checkpoint.
 
-2. COMMAND LINE - Export with Raven sigmoid compensation (RECOMMENDED):
+2. COMMAND LINE - Legacy sigmoid compensation (older Raven versions only):
    -------------------------------------------------------------------------
-   Raven Intelligence applies sigmoid independently to each model output.
-   Use --compensate-for-sigmoid so that Raven's sigmoid recovers correct
-   softmax probabilities (scores sum to 1.0 with proper calibration):
+   Use --compensate-for-sigmoid when sigmoid cannot be disabled in Raven. See OUTPUT
+   POST-PROCESSING OPTIONS below for details.
 
    python scripts/raven_export.py /path/to/checkpoint/best.pth \\
        --output-dir ~/Raven\ Workbench/Raven\ Intelligence/Models/ \\
@@ -48,7 +47,6 @@ USAGE EXAMPLES
        output_dir='~/Raven Workbench/Raven Intelligence/Models/',
        model_name='My_Detector',
        export_format='torchscript',  # recommended; 'onnx' also available
-       compensate_for_sigmoid=True,  # recommended for Raven Intelligence
    )
 
 4. PYTHON API - Package an existing TorchScript model:
@@ -126,13 +124,13 @@ NOTES
 - Output tensor shape: (batch, num_classes)
 
 OUTPUT POST-PROCESSING OPTIONS:
-- --compensate-for-sigmoid (RECOMMENDED): outputs inverse-sigmoid of softmax probs.
-  Raven's sigmoid then recovers exact softmax probabilities (sum to 1.0).
-  This is the correct option for calibrated scores in both binary and multiclass models.
-- --no-softmax: outputs raw logits. Raven's sigmoid gives usable but uncalibrated
-  scores that do not sum to 1.0. May suffice for binary models with threshold tuning.
-- (default): outputs softmax probabilities directly. NOT recommended for Raven, as
-  Raven's sigmoid will double-transform the scores into a compressed range.
+- (default, RECOMMENDED): outputs softmax probabilities directly. Use this with sigmoid
+  disabled in Raven Intelligence settings (available in current Raven releases).
+- --no-softmax: outputs raw logits. Use when Raven's sigmoid is enabled — gives usable
+  but uncalibrated scores that do not sum to 1.0.
+- --compensate-for-sigmoid (LEGACY): outputs inverse-sigmoid of softmax probs, so that
+  Raven's sigmoid recovers exact softmax probabilities (sum to 1.0). Workaround for
+  older Raven versions that had no option to disable sigmoid.
 
 =========================================================================================
 """
@@ -950,7 +948,10 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(
-        description='Export soundbay model to Raven Intelligence format'
+        description=(
+            'Export soundbay model to Raven Intelligence format. '
+            'Default (recommended): softmax output — disable sigmoid in Raven Intelligence settings.'
+        )
     )
     parser.add_argument(
         'checkpoint',
@@ -977,7 +978,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--compensate-for-sigmoid',
         action='store_true',
-        help='Apply softmax then inverse-sigmoid so Raven\'s sigmoid recovers correct softmax probabilities'
+        help='Legacy: apply softmax then inverse-sigmoid for older Raven versions without a sigmoid disable option'
     )
     parser.add_argument(
         '--format',

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -172,40 +172,28 @@ class PeakNormalizeModule(nn.Module):
     """
     nn.Module version of PeakNormalize for TorchScript export compatibility.
 
-    This is a re-implementation of soundbay.data.PeakNormalize as an nn.Module.
-    The original class uses __call__ which doesn't trace properly for TorchScript.
+    The original class is not an nn.Module so it can't be traced by TorchScript.
+    This wrapper preserves the exact same logic (global min/max across all dims).
 
     See: soundbay/data.py::PeakNormalize
-
-    IMPORTANT: Logic must match the original exactly to ensure consistent inference.
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Per-sample normalization: reduce all dims except batch, keepdim for broadcasting
-        dims = list(range(1, x.dim()))
-        x_min = x.amin(dim=dims, keepdim=True)
-        x_max = x.amax(dim=dims, keepdim=True)
-        return (x - x_min) / (x_max - x_min + 1e-8)
+        return (x - x.min()) / (x.max() - x.min() + 1e-8)
 
 
 class UnitNormalizeModule(nn.Module):
     """
     nn.Module version of UnitNormalize for TorchScript export compatibility.
 
-    This is a re-implementation of soundbay.data.UnitNormalize as an nn.Module.
-    The original class uses __call__ which doesn't trace properly for TorchScript.
+    The original class is not an nn.Module so it can't be traced by TorchScript.
+    This wrapper preserves the exact same logic (global mean/std across all dims).
 
     See: soundbay/data.py::UnitNormalize
-
-    IMPORTANT: Logic must match the original exactly to ensure consistent inference.
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Per-sample normalization: reduce all dims except batch, keepdim for broadcasting
-        dims = list(range(1, x.dim()))
-        x_mean = x.mean(dim=dims, keepdim=True)
-        x_std = x.std(dim=dims, keepdim=True)
-        return (x - x_mean) / (x_std + 1e-8)
+        return (x - x.mean()) / (x.std() + 1e-8)
 
 
 class LibrosaPcenModule(nn.Module):
@@ -367,11 +355,16 @@ class PreprocessingPipeline(nn.Module):
                 pcen_module = LibrosaPcenModule(sr=sr, hop_length=hop_length)
                 processors.append(torch.jit.script(pcen_module))
             elif 'MinFreqFiltering' in target:
-                # MinFreqFiltering is a no-op when the channel dim is 1:
-                # min_bin = int(floor(size(dim=1) * min_freq / (sr/2))) = 0
-                # So sample[:, 0:, :] returns the full tensor.
-                # Replace with Identity to avoid numpy dependency.
+                # MinFreqFiltering uses numpy so can't be traced. It's a no-op
+                # when min_freq_filtering=0 (slices sample[:, 0:, :] = full tensor).
                 # See: soundbay/data.py::MinFreqFiltering
+                min_freq = config.get('min_freq_filtering', 0)
+                if min_freq != 0:
+                    raise ValueError(
+                        f"MinFreqFiltering with min_freq_filtering={min_freq} is not "
+                        f"supported for TorchScript export. Only min_freq_filtering=0 "
+                        f"(no-op) is supported."
+                    )
                 processors.append(nn.Identity())
             elif 'PeakNormalize' in target:
                 # Use nn.Module version for TorchScript compatibility

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -168,15 +168,28 @@ def _get_model_class(model_target: str):
     return MODEL_REGISTRY[model_target]
 
 
+# NOTE ON NORMALIZATION AND BATCH DIMENSIONS:
+#
+# The original PeakNormalize and UnitNormalize in soundbay/data.py use global
+# reductions (sample.min(), sample.mean(), etc.) that reduce ALL dimensions.
+# This works correctly during training because they run per-sample inside
+# __getitem__ — there is no batch dimension at that point.
+#
+# In the exported model, Raven Intelligence may send batches with batch_size > 1.
+# Using global reduction on a batch would normalize across samples (wrong — one
+# loud sample would affect the normalization of a quiet one). Instead, we reduce
+# all dims EXCEPT the batch dim, so each sample is normalized independently —
+# exactly as the original would process them one at a time.
+#
+# The code LOOKS different from the original (amin over explicit dims vs .min()),
+# but the semantics are identical: per-sample normalization.
+
+
 class PeakNormalizeModule(nn.Module):
     """
     nn.Module version of PeakNormalize for TorchScript export compatibility.
-
-    The original (soundbay/data.py::PeakNormalize) uses sample.min()/sample.max()
-    which reduces ALL dims. That's fine because it runs per-sample inside __getitem__
-    (no batch dim). Here we reduce all dims EXCEPT batch so that each sample in a
-    batch is normalized independently — matching the original's per-sample semantics
-    even when Raven sends batch_size > 1.
+    See note above on batch dimension handling.
+    See: soundbay/data.py::PeakNormalize
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -189,12 +202,8 @@ class PeakNormalizeModule(nn.Module):
 class UnitNormalizeModule(nn.Module):
     """
     nn.Module version of UnitNormalize for TorchScript export compatibility.
-
-    The original (soundbay/data.py::UnitNormalize) uses sample.mean()/sample.std()
-    which reduces ALL dims. That's fine because it runs per-sample inside __getitem__
-    (no batch dim). Here we reduce all dims EXCEPT batch so that each sample in a
-    batch is normalized independently — matching the original's per-sample semantics
-    even when Raven sends batch_size > 1.
+    See note above PeakNormalizeModule on batch dimension handling.
+    See: soundbay/data.py::UnitNormalize
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -20,14 +20,26 @@ USAGE EXAMPLES
        --format torchscript
 
    Options:
-     --output-dir   Output directory for the model package (default: current dir)
-     --name         Model name (default: checkpoint directory name)
-     --format       Export format: 'torchscript' (default) or 'onnx'
-     --no-softmax   Do not apply softmax to outputs
+     --output-dir                Output directory for the model package (default: current dir)
+     --name                      Model name (default: checkpoint directory name)
+     --format                    Export format: 'torchscript' (default) or 'onnx'
+     --no-softmax                Do not apply softmax to outputs (raw logits)
+     --compensate-for-sigmoid    Apply softmax + inverse-sigmoid (recommended, see below)
 
    This requires args.yaml to be in the same directory as the checkpoint.
 
-2. PYTHON API - Export from soundbay checkpoint:
+2. COMMAND LINE - Export with Raven sigmoid compensation (RECOMMENDED):
+   -------------------------------------------------------------------------
+   Raven Intelligence applies sigmoid independently to each model output.
+   Use --compensate-for-sigmoid so that Raven's sigmoid recovers correct
+   softmax probabilities (scores sum to 1.0 with proper calibration):
+
+   python scripts/raven_export.py /path/to/checkpoint/best.pth \\
+       --output-dir ~/Raven\ Workbench/Raven\ Intelligence/Models/ \\
+       --name My_Detector \\
+       --compensate-for-sigmoid
+
+3. PYTHON API - Export from soundbay checkpoint:
    -------------------------------------------------------------------------
    from scripts.raven_export import create_raven_model_package
 
@@ -36,9 +48,10 @@ USAGE EXAMPLES
        output_dir='~/Raven Workbench/Raven Intelligence/Models/',
        model_name='My_Detector',
        export_format='torchscript',  # recommended; 'onnx' also available
+       compensate_for_sigmoid=True,  # recommended for Raven Intelligence
    )
 
-3. PYTHON API - Package an existing TorchScript model:
+4. PYTHON API - Package an existing TorchScript model:
    -------------------------------------------------------------------------
    from scripts.raven_export import create_raven_model_package_from_torchscript
 
@@ -86,10 +99,11 @@ SUPPORTED PREPROCESSORS
 The following preprocessors from soundbay/data.py are supported:
 - PeakNormalize (re-implemented as nn.Module for TorchScript compatibility)
 - UnitNormalize (re-implemented as nn.Module for TorchScript compatibility)
-- All torchaudio.transforms (MelSpectrogram, AmplitudeToDB, etc.)
+- LibrosaPcen (re-implemented as nn.Module with torch.jit.script for IIR loop)
+- MinFreqFiltering (replaced with nn.Identity - no-op when channel dim is 1)
+- All torchaudio.transforms (MelSpectrogram, Spectrogram, AmplitudeToDB, etc.)
 
 NOT supported (will raise an error):
-- MinFreqFiltering: uses numpy operations that cannot be traced
 - SlidingWindowNormalize: uses numpy and random operations
 
 =========================================================================================
@@ -105,16 +119,26 @@ NOTES
 
 - TorchScript export is recommended over ONNX (STFT operations not supported in ONNX)
 - The wrapper embeds all preprocessing (resampling, MelSpectrogram, normalization)
-  so the exported model accepts raw audio and outputs class probabilities
+  so the exported model accepts raw audio and outputs class scores
 - Raven Intelligence uses DJL with PyTorch 2.5.1 - ensure version compatibility
-- Input tensor shape: (batch, samples) for models exported via create_raven_model_package
-- Input tensor shape: (batch, channels, samples) for pre-existing TorchScript models
-- Output tensor shape: (batch, num_classes) with softmax probabilities
+- Input tensor shape: (batch, channels, samples) - matches both soundbay's training
+  data format (where _get_audio returns (1, samples)) and Raven's expected interface
+- Output tensor shape: (batch, num_classes)
+
+OUTPUT POST-PROCESSING OPTIONS:
+- --compensate-for-sigmoid (RECOMMENDED): outputs inverse-sigmoid of softmax probs.
+  Raven's sigmoid then recovers exact softmax probabilities (sum to 1.0).
+  This is the correct option for calibrated scores in both binary and multiclass models.
+- --no-softmax: outputs raw logits. Raven's sigmoid gives usable but uncalibrated
+  scores that do not sum to 1.0. May suffice for binary models with threshold tuning.
+- (default): outputs softmax probabilities directly. NOT recommended for Raven, as
+  Raven's sigmoid will double-transform the scores into a compressed range.
 
 =========================================================================================
 """
 
 import json
+import math
 import shutil
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -184,6 +208,78 @@ class UnitNormalizeModule(nn.Module):
         return (x - x_mean) / (x_std + 1e-8)
 
 
+class LibrosaPcenModule(nn.Module):
+    """
+    nn.Module version of LibrosaPcen for TorchScript export compatibility.
+
+    Implements Per-Channel Energy Normalization (PCEN) as a pure PyTorch nn.Module,
+    mathematically equivalent to librosa.core.pcen as called by
+    soundbay.utils.signal_processing.LibrosaPcen.
+
+    The IIR smoothing filter requires a loop over time frames, so this module
+    must be torch.jit.script'd (not traced) before inclusion in a traced pipeline.
+
+    See: soundbay/utils/signal_processing.py::LibrosaPcen
+         soundbay/models.py::PCENTransform.pcen (similar but different initialization)
+
+    IMPORTANT: The smoothing coefficient 'b' and initial conditions match librosa's
+    implementation exactly (using scipy.signal.lfilter_zi steady-state initialization),
+    NOT the simpler PCENTransform.pcen initialization. This is critical because the
+    barks model was trained with LibrosaPcen → librosa.core.pcen.
+    """
+
+    def __init__(
+        self,
+        sr: int,
+        hop_length: int,
+        gain: float = 0.6,
+        bias: float = 0.1,
+        power: float = 0.2,
+        time_constant: float = 0.4,
+        eps: float = 1e-9,
+    ):
+        super().__init__()
+        # Compute smoothing coefficient from time_constant, matching librosa.core.pcen:
+        #   t_frames = time_constant * sr / hop_length
+        #   b = (sqrt(1 + 4 * t_frames^2) - 1) / (2 * t_frames^2)
+        t_frames = time_constant * sr / float(hop_length)
+        b = (math.sqrt(1 + 4 * t_frames ** 2) - 1) / (2 * t_frames ** 2)
+
+        self.b: float = b
+        self.gain: float = gain
+        self.bias: float = bias
+        self.power: float = power
+        self.eps: float = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Apply PCEN normalization along the time axis (last dimension).
+
+        Args:
+            x: Spectrogram tensor of shape (batch, channels, freq, time)
+
+        Returns:
+            PCEN-normalized tensor of same shape
+        """
+        b = self.b
+
+        # IIR filter along time axis, matching librosa's lfilter initialization.
+        # librosa uses zi = lfilter_zi([b], [1, b-1]) = [1-b] (unscaled),
+        # so M[0] = b * S[0] + (1-b), NOT M[0] = S[0].
+        m = x[..., :1] * b + (1.0 - b)
+        m_frames: List[torch.Tensor] = [m]
+
+        for t in range(1, x.shape[-1]):
+            m = (1.0 - b) * m + b * x[..., t : t + 1]
+            m_frames.append(m)
+
+        M = torch.cat(m_frames, dim=-1)
+
+        # PCEN formula: (S / (M + eps)^gain + bias)^power - bias^power
+        pcen = (x / (M + self.eps).pow(self.gain) + self.bias).pow(self.power) - self.bias ** self.power
+        return pcen
+
+
 class PreprocessingPipeline(nn.Module):
     """
     A torch.nn.Module that encapsulates the preprocessing pipeline from args.yaml.
@@ -239,9 +335,8 @@ class PreprocessingPipeline(nn.Module):
             return nn.Identity()
 
         # Preprocessors that are NOT supported for TorchScript export:
-        # - MinFreqFiltering: uses numpy operations
         # - SlidingWindowNormalize: uses numpy and random operations
-        unsupported = ['MinFreqFiltering', 'SlidingWindowNormalize']
+        unsupported = ['SlidingWindowNormalize']
 
         for name, config in preprocessors_config.items():
             target = config.get('_target_', '')
@@ -255,7 +350,30 @@ class PreprocessingPipeline(nn.Module):
                         f"See soundbay/data.py for the original implementation."
                     )
 
-            if 'PeakNormalize' in target:
+            if 'LibrosaPcen' in target:
+                # Use nn.Module PCEN for TorchScript compatibility.
+                # Must be torch.jit.script'd because the IIR loop can't be traced.
+                # See: soundbay/utils/signal_processing.py::LibrosaPcen
+                sr = config.get('sr')
+                # Support both 'hop_length' (current config) and 'n_mels' (legacy config)
+                hop_length = config.get('hop_length')
+                if hop_length is None:
+                    n_mels = config.get('n_mels')
+                    if n_mels is None:
+                        raise ValueError(
+                            "LibrosaPcen config must have 'hop_length' or 'n_mels'"
+                        )
+                    hop_length = int(sr / n_mels)
+                pcen_module = LibrosaPcenModule(sr=sr, hop_length=hop_length)
+                processors.append(torch.jit.script(pcen_module))
+            elif 'MinFreqFiltering' in target:
+                # MinFreqFiltering is a no-op when the channel dim is 1:
+                # min_bin = int(floor(size(dim=1) * min_freq / (sr/2))) = 0
+                # So sample[:, 0:, :] returns the full tensor.
+                # Replace with Identity to avoid numpy dependency.
+                # See: soundbay/data.py::MinFreqFiltering
+                processors.append(nn.Identity())
+            elif 'PeakNormalize' in target:
                 # Use nn.Module version for TorchScript compatibility
                 # See: soundbay/data.py::PeakNormalize
                 processors.append(PeakNormalizeModule())
@@ -275,15 +393,14 @@ class PreprocessingPipeline(nn.Module):
         Apply preprocessing to raw audio.
 
         Args:
-            x: Raw audio tensor of shape (batch, samples) or (batch, 1, samples)
+            x: Raw audio tensor of shape (batch, channels, samples)
+               This matches soundbay's training data format where _get_audio
+               returns (1, samples) per sample, batched to (batch, 1, samples).
+               Raven Intelligence also sends 3D (batch, channels, samples).
 
         Returns:
             Preprocessed tensor ready for the model
         """
-        # Ensure correct shape: (batch, 1, samples)
-        if x.dim() == 2:
-            x = x.unsqueeze(1)
-
         # Apply resampling
         x = self.resampler(x)
 
@@ -300,7 +417,7 @@ class RavenExportModel(nn.Module):
     This model accepts raw audio as input and outputs class scores,
     matching Raven Intelligence's expected interface.
 
-    Input: Raw audio tensor (batch, samples) at data_sample_rate
+    Input: Raw audio tensor (batch, channels, samples) at data_sample_rate
     Output: Class probabilities (batch, num_classes)
     """
 
@@ -309,6 +426,7 @@ class RavenExportModel(nn.Module):
         model: nn.Module,
         preprocessing: PreprocessingPipeline,
         apply_softmax: bool = True,
+        compensate_for_sigmoid: bool = False,
     ):
         """
         Initialize the export model.
@@ -317,30 +435,42 @@ class RavenExportModel(nn.Module):
             model: The trained soundbay model
             preprocessing: The preprocessing pipeline
             apply_softmax: Whether to apply softmax to outputs (recommended for Raven)
+            compensate_for_sigmoid: Apply softmax then inverse-sigmoid, so that
+                Raven's sigmoid post-processing recovers correct softmax probabilities.
+                Overrides apply_softmax when True.
         """
         super().__init__()
 
         self.preprocessing = preprocessing
         self.model = model
         self.apply_softmax = apply_softmax
+        self.compensate_for_sigmoid = compensate_for_sigmoid
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass from raw audio to class scores.
 
         Args:
-            x: Raw audio tensor of shape (batch, samples)
+            x: Raw audio tensor of shape (batch, samples) as sent by DJL
 
         Returns:
             Class probabilities of shape (batch, num_classes)
         """
+        # DJL sends 2D (batch, samples) even when config specifies channels.
+        # Add channel dim for torchaudio transforms.
+        x = x.unsqueeze(1)
+
         # Apply preprocessing
         x = self.preprocessing(x)
 
         # Run through model
         logits = self.model(x)
 
-        # Apply softmax for probabilities
+        # Post-processing: compensate for Raven's sigmoid, plain softmax, or raw logits
+        if self.compensate_for_sigmoid:
+            probs = torch.softmax(logits, dim=-1)
+            probs = probs.clamp(1e-7, 1 - 1e-7)
+            return torch.log(probs / (1 - probs))  # inverse sigmoid
         if self.apply_softmax:
             return torch.softmax(logits, dim=-1)
         return logits
@@ -351,6 +481,7 @@ class RavenExportModel(nn.Module):
         checkpoint_path: Union[str, Path],
         args_path: Optional[Union[str, Path]] = None,
         apply_softmax: bool = True,
+        compensate_for_sigmoid: bool = False,
     ) -> 'RavenExportModel':
         """
         Create a RavenExportModel from a soundbay checkpoint.
@@ -359,6 +490,7 @@ class RavenExportModel(nn.Module):
             checkpoint_path: Path to the .pth checkpoint file
             args_path: Path to args.yaml. If None, looks for it in the same directory
             apply_softmax: Whether to apply softmax to outputs
+            compensate_for_sigmoid: Apply softmax then inverse-sigmoid for Raven compatibility
 
         Returns:
             RavenExportModel ready for export
@@ -410,7 +542,8 @@ class RavenExportModel(nn.Module):
             preprocessors_config=dict(args.get('_preprocessors', {})),
         )
 
-        return cls(model=model, preprocessing=preprocessing, apply_softmax=apply_softmax)
+        return cls(model=model, preprocessing=preprocessing, apply_softmax=apply_softmax,
+                   compensate_for_sigmoid=compensate_for_sigmoid)
 
     def get_config(self, checkpoint_path: Union[str, Path]) -> dict:
         """
@@ -463,7 +596,8 @@ def export_to_onnx(
     # Calculate input size: samples = sample_rate * seq_length
     num_samples = int(sample_rate * seq_length)
 
-    # Create dummy input (batch_size=1)
+    # Create dummy input (batch_size=1, samples)
+    # 2D: DJL sends (batch, samples). Model unsqueezes channel dim internally.
     dummy_input = torch.randn(1, num_samples)
 
     # Export to ONNX
@@ -515,13 +649,22 @@ def export_to_torchscript(
     # Calculate input size: samples = sample_rate * seq_length
     num_samples = int(sample_rate * seq_length)
 
-    # Create dummy input (batch_size=1)
+    # Create dummy input (batch_size=1, samples)
+    # 2D: DJL sends (batch, samples). Model unsqueezes channel dim internally.
     dummy_input = torch.randn(1, num_samples)
 
-    # Use tracing for export (works better with dynamic ops like STFT)
+    # Use tracing for export (works better with dynamic ops like STFT).
+    # Note: any scripted submodules (e.g. LibrosaPcenModule) are preserved
+    # correctly within the traced graph.
     print("  Tracing model with TorchScript (this may take a moment)...")
     with torch.no_grad():
         traced_model = torch.jit.trace(model, dummy_input)
+
+    # Freeze the graph: inlines parameters/buffers as constants (model is in eval-mode).
+    # Note: optimize_for_inference() is intentionally omitted — its graph rewrites
+    # can be incompatible with DJL's PyTorch engine (e.g., dimension mismatches).
+    print("  Freezing model graph...")
+    traced_model = torch.jit.freeze(traced_model)
 
     # Save the traced model
     print("  Saving traced model...")
@@ -536,6 +679,7 @@ def create_raven_model_package(
     output_dir: Union[str, Path],
     model_name: str,
     apply_softmax: bool = True,
+    compensate_for_sigmoid: bool = False,
     export_format: str = 'torchscript',
 ) -> Path:
     """
@@ -551,6 +695,7 @@ def create_raven_model_package(
         output_dir: Directory to create the model package in
         model_name: Name for the model
         apply_softmax: Whether to apply softmax in the model
+        compensate_for_sigmoid: Apply softmax then inverse-sigmoid for Raven compatibility
         export_format: 'torchscript' (default, recommended) or 'onnx'
 
     Returns:
@@ -572,6 +717,7 @@ def create_raven_model_package(
     export_model = RavenExportModel.from_checkpoint(
         checkpoint_path=checkpoint_path,
         apply_softmax=apply_softmax,
+        compensate_for_sigmoid=compensate_for_sigmoid,
     )
 
     # Get configuration
@@ -731,8 +877,8 @@ def create_raven_model_package_from_torchscript(
     num_samples = int(sample_rate * seq_length)
     num_classes = len(label_names)
 
-    # Determine input tensor dimensions based on channels
-    input_dims = [-1, input_channels, num_samples]
+    # DJL sends 2D (batch, samples) regardless of channel config
+    input_dims = [-1, num_samples]
 
     # Create .ravenmodel configuration
     ravenmodel_config = {
@@ -819,6 +965,11 @@ if __name__ == '__main__':
         help='Do not apply softmax to outputs'
     )
     parser.add_argument(
+        '--compensate-for-sigmoid',
+        action='store_true',
+        help='Apply softmax then inverse-sigmoid so Raven\'s sigmoid recovers correct softmax probabilities'
+    )
+    parser.add_argument(
         '--format',
         type=str,
         default='torchscript',
@@ -836,5 +987,6 @@ if __name__ == '__main__':
         output_dir=args.output_dir,
         model_name=model_name,
         apply_softmax=not args.no_softmax,
+        compensate_for_sigmoid=args.compensate_for_sigmoid,
         export_format=args.format,
     )

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -157,8 +157,11 @@ class PeakNormalizeModule(nn.Module):
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Match original: (sample - sample.min()) / (sample.max() - sample.min() + 1e-8)
-        return (x - x.min()) / (x.max() - x.min() + 1e-8)
+        # Per-sample normalization: reduce all dims except batch, keepdim for broadcasting
+        dims = list(range(1, x.dim()))
+        x_min = x.amin(dim=dims, keepdim=True)
+        x_max = x.amax(dim=dims, keepdim=True)
+        return (x - x_min) / (x_max - x_min + 1e-8)
 
 
 class UnitNormalizeModule(nn.Module):
@@ -174,8 +177,11 @@ class UnitNormalizeModule(nn.Module):
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Match original: (sample - sample.mean()) / (sample.std() + 1e-8)
-        return (x - x.mean()) / (x.std() + 1e-8)
+        # Per-sample normalization: reduce all dims except batch, keepdim for broadcasting
+        dims = list(range(1, x.dim()))
+        x_mean = x.mean(dim=dims, keepdim=True)
+        x_std = x.std(dim=dims, keepdim=True)
+        return (x - x_mean) / (x_std + 1e-8)
 
 
 class PreprocessingPipeline(nn.Module):

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -378,9 +378,11 @@ class RavenExportModel(nn.Module):
             raise FileNotFoundError(f"args.yaml not found at {args_path}")
 
         # Load configuration
+        print("  Loading configuration...")
         args = OmegaConf.load(args_path)
 
         # Load checkpoint
+        print("  Loading model weights...")
         checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=False)
 
         # Create model
@@ -392,13 +394,16 @@ class RavenExportModel(nn.Module):
         # Force pretrained=False since we're loading weights from checkpoint
         model_kwargs = {k: v for k, v in model_config.items() if k != '_target_'}
         model_kwargs['pretrained'] = False
+        print(f"  Creating {model_target} model...")
         model = model_class(**model_kwargs)
 
         # Load weights
+        print("  Loading trained weights...")
         model.load_state_dict(checkpoint['model'])
         model.eval()
 
         # Create preprocessing pipeline
+        print("  Building preprocessing pipeline...")
         preprocessing = PreprocessingPipeline(
             data_sample_rate=args.data.data_sample_rate,
             sample_rate=args.data.sample_rate,
@@ -514,10 +519,12 @@ def export_to_torchscript(
     dummy_input = torch.randn(1, num_samples)
 
     # Use tracing for export (works better with dynamic ops like STFT)
+    print("  Tracing model with TorchScript (this may take a moment)...")
     with torch.no_grad():
         traced_model = torch.jit.trace(model, dummy_input)
 
     # Save the traced model
+    print("  Saving traced model...")
     traced_model.save(str(output_path))
 
     print(f"Exported TorchScript model to {output_path}")
@@ -552,12 +559,16 @@ def create_raven_model_package(
     checkpoint_path = Path(checkpoint_path)
     output_dir = Path(output_dir)
 
+    print(f"\n{'='*60}")
+    print(f"Exporting model: {model_name}")
+    print(f"{'='*60}")
+
     # Load args for configuration
     args_path = checkpoint_path.parent / 'args.yaml'
     args = OmegaConf.load(args_path)
 
     # Create the export model
-    print(f"Loading checkpoint from {checkpoint_path}...")
+    print(f"\nStep 1/4: Loading checkpoint from {checkpoint_path}")
     export_model = RavenExportModel.from_checkpoint(
         checkpoint_path=checkpoint_path,
         apply_softmax=apply_softmax,
@@ -571,6 +582,7 @@ def create_raven_model_package(
     model_dir.mkdir(parents=True, exist_ok=True)
 
     # Export model based on format
+    print(f"\nStep 2/4: Exporting to {export_format} format")
     if export_format == 'torchscript':
         model_path = model_dir / 'model.pt'
         export_to_torchscript(
@@ -593,11 +605,12 @@ def create_raven_model_package(
         raise ValueError(f"Unknown export format: {export_format}. Use 'torchscript' or 'onnx'")
 
     # Create labels file
+    print(f"\nStep 3/4: Creating labels file")
     labels_path = model_dir / 'labels.txt'
     with open(labels_path, 'w') as f:
         for label in config['label_names']:
             f.write(f"{label}\n")
-    print(f"Created labels file at {labels_path}")
+    print(f"  Labels: {config['label_names']}")
 
     # Calculate input dimensions
     num_samples = int(config['data_sample_rate'] * config['seq_length'])
@@ -643,12 +656,13 @@ def create_raven_model_package(
     }
 
     # Write .ravenmodel file
+    print(f"\nStep 4/4: Creating .ravenmodel configuration")
     ravenmodel_path = output_dir / f"{model_name}.ravenmodel"
     with open(ravenmodel_path, 'w') as f:
         json.dump(ravenmodel_config, f, indent=2)
-    print(f"Created .ravenmodel file at {ravenmodel_path}")
 
-    print(f"\nRaven model package created successfully!")
+    print(f"\n{'='*60}")
+    print(f"SUCCESS! Raven model package created")
     print(f"  Model directory: {model_dir}")
     print(f"  Configuration: {ravenmodel_path}")
     print(f"\nTo use in Raven Intelligence:")

--- a/scripts/raven_export.py
+++ b/scripts/raven_export.py
@@ -172,28 +172,36 @@ class PeakNormalizeModule(nn.Module):
     """
     nn.Module version of PeakNormalize for TorchScript export compatibility.
 
-    The original class is not an nn.Module so it can't be traced by TorchScript.
-    This wrapper preserves the exact same logic (global min/max across all dims).
-
-    See: soundbay/data.py::PeakNormalize
+    The original (soundbay/data.py::PeakNormalize) uses sample.min()/sample.max()
+    which reduces ALL dims. That's fine because it runs per-sample inside __getitem__
+    (no batch dim). Here we reduce all dims EXCEPT batch so that each sample in a
+    batch is normalized independently — matching the original's per-sample semantics
+    even when Raven sends batch_size > 1.
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return (x - x.min()) / (x.max() - x.min() + 1e-8)
+        dims = list(range(1, x.dim()))
+        x_min = x.amin(dim=dims, keepdim=True)
+        x_max = x.amax(dim=dims, keepdim=True)
+        return (x - x_min) / (x_max - x_min + 1e-8)
 
 
 class UnitNormalizeModule(nn.Module):
     """
     nn.Module version of UnitNormalize for TorchScript export compatibility.
 
-    The original class is not an nn.Module so it can't be traced by TorchScript.
-    This wrapper preserves the exact same logic (global mean/std across all dims).
-
-    See: soundbay/data.py::UnitNormalize
+    The original (soundbay/data.py::UnitNormalize) uses sample.mean()/sample.std()
+    which reduces ALL dims. That's fine because it runs per-sample inside __getitem__
+    (no batch dim). Here we reduce all dims EXCEPT batch so that each sample in a
+    batch is normalized independently — matching the original's per-sample semantics
+    even when Raven sends batch_size > 1.
     """
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return (x - x.mean()) / (x.std() + 1e-8)
+        dims = list(range(1, x.dim()))
+        x_mean = x.mean(dim=dims, keepdim=True)
+        x_std = x.std(dim=dims, keepdim=True)
+        return (x - x_mean) / (x_std + 1e-8)
 
 
 class LibrosaPcenModule(nn.Module):

--- a/soundbay/raven_export.py
+++ b/soundbay/raven_export.py
@@ -1,0 +1,316 @@
+"""
+Raven Intelligence Export Module
+
+This module provides utilities to export soundbay models to Raven Intelligence format.
+It wraps trained models with their preprocessing pipeline to create standalone models
+that accept raw audio input, compatible with Raven Intelligence's expected interface.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import torch
+import torch.nn as nn
+import torchaudio
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+
+
+def _get_model_class(model_target: str):
+    """
+    Lazy import of model classes to avoid transformers dependency when not needed.
+    """
+    if model_target == 'models.ResNet182D':
+        # Import inline to avoid loading transformers-dependent modules
+        import torch.nn as nn
+        from torchvision import models as tv_models
+        from torchvision.models import ResNet18_Weights
+
+        class ResNet182D(nn.Module):
+            def __init__(self, num_classes=2, pretrained=True):
+                super(ResNet182D, self).__init__()
+                resnet = tv_models.resnet18(weights=ResNet18_Weights.DEFAULT) if pretrained else tv_models.resnet18(weights=None)
+                num_features = resnet.fc.in_features
+                resnet.fc = nn.Sequential(
+                    nn.Linear(num_features, 256),
+                    nn.ReLU(),
+                    nn.Dropout(0.5),
+                    nn.Linear(256, num_classes)
+                )
+                self.resnet = resnet
+
+            def forward(self, x):
+                x = x.repeat(1, 3, 1, 1)
+                return self.resnet(x)
+
+        return ResNet182D
+
+    elif model_target == 'models.Squeezenet2D':
+        import torch.nn as nn
+
+        class Squeezenet2D(nn.Module):
+            def __init__(self, num_classes=2, pretrained=True):
+                super(Squeezenet2D, self).__init__()
+                self.squeezenet = torch.hub.load('pytorch/vision:v0.10.0', 'squeezenet1_0', pretrained=pretrained)
+                num_features = self.squeezenet.classifier[1].out_channels
+                self.custom_classifier = nn.Sequential(
+                    nn.Linear(num_features, 256),
+                    nn.ReLU(),
+                    nn.Dropout(0.5),
+                    nn.Linear(256, num_classes)
+                )
+
+            def forward(self, x):
+                x = x.repeat(1, 3, 1, 1)
+                rep = self.squeezenet(x)
+                return self.custom_classifier(rep)
+
+        return Squeezenet2D
+
+    else:
+        raise ValueError(f"Unknown or unsupported model type for export: {model_target}. "
+                        f"Supported: models.ResNet182D, models.Squeezenet2D")
+
+
+class PeakNormalizeModule(nn.Module):
+    """nn.Module version of PeakNormalize for export compatibility."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_min = x.amin(dim=(-2, -1), keepdim=True)
+        x_max = x.amax(dim=(-2, -1), keepdim=True)
+        return (x - x_min) / (x_max - x_min + 1e-8)
+
+
+class UnitNormalizeModule(nn.Module):
+    """nn.Module version of UnitNormalize for export compatibility."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        mean = x.mean(dim=(-2, -1), keepdim=True)
+        std = x.std(dim=(-2, -1), keepdim=True)
+        return (x - mean) / (std + 1e-8)
+
+
+class PreprocessingPipeline(nn.Module):
+    """
+    A torch.nn.Module that encapsulates the preprocessing pipeline from args.yaml.
+
+    This module applies:
+    1. Resampling (if data_sample_rate != sample_rate)
+    2. Preprocessors (MelSpectrogram, AmplitudeToDB, normalization, etc.)
+
+    All operations are performed using torch operations to ensure export compatibility.
+    """
+
+    def __init__(
+        self,
+        data_sample_rate: int,
+        sample_rate: int,
+        preprocessors_config: Dict,
+    ):
+        """
+        Initialize the preprocessing pipeline.
+
+        Args:
+            data_sample_rate: Original sample rate of input audio
+            sample_rate: Target sample rate for the model
+            preprocessors_config: Dictionary of preprocessor configurations from args.yaml
+        """
+        super().__init__()
+
+        self.data_sample_rate = data_sample_rate
+        self.sample_rate = sample_rate
+
+        # Resampler
+        if data_sample_rate != sample_rate:
+            self.resampler = torchaudio.transforms.Resample(
+                orig_freq=data_sample_rate,
+                new_freq=sample_rate
+            )
+        else:
+            self.resampler = nn.Identity()
+
+        # Build preprocessor pipeline
+        self.preprocessors = self._build_preprocessors(preprocessors_config)
+
+    def _build_preprocessors(self, preprocessors_config: Dict) -> nn.Sequential:
+        """
+        Build the preprocessing pipeline from config.
+
+        Handles special cases like PeakNormalize which need to be converted
+        to proper nn.Module instances for export.
+        """
+        processors = []
+
+        if preprocessors_config is None or len(preprocessors_config) == 0:
+            return nn.Identity()
+
+        for name, config in preprocessors_config.items():
+            target = config.get('_target_', '')
+
+            if 'PeakNormalize' in target:
+                processors.append(PeakNormalizeModule())
+            elif 'UnitNormalize' in target:
+                processors.append(UnitNormalizeModule())
+            else:
+                # Use hydra instantiate for standard transforms
+                processor = instantiate(config)
+                processors.append(processor)
+
+        return nn.Sequential(*processors)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Apply preprocessing to raw audio.
+
+        Args:
+            x: Raw audio tensor of shape (batch, samples) or (batch, 1, samples)
+
+        Returns:
+            Preprocessed tensor ready for the model
+        """
+        # Ensure correct shape: (batch, 1, samples)
+        if x.dim() == 2:
+            x = x.unsqueeze(1)
+
+        # Apply resampling
+        x = self.resampler(x)
+
+        # Apply preprocessors
+        x = self.preprocessors(x)
+
+        return x
+
+
+class RavenExportModel(nn.Module):
+    """
+    A wrapper model that combines preprocessing and the trained model.
+
+    This model accepts raw audio as input and outputs class scores,
+    matching Raven Intelligence's expected interface.
+
+    Input: Raw audio tensor (batch, samples) at data_sample_rate
+    Output: Class probabilities (batch, num_classes)
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        preprocessing: PreprocessingPipeline,
+        apply_softmax: bool = True,
+    ):
+        """
+        Initialize the export model.
+
+        Args:
+            model: The trained soundbay model
+            preprocessing: The preprocessing pipeline
+            apply_softmax: Whether to apply softmax to outputs (recommended for Raven)
+        """
+        super().__init__()
+
+        self.preprocessing = preprocessing
+        self.model = model
+        self.apply_softmax = apply_softmax
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass from raw audio to class scores.
+
+        Args:
+            x: Raw audio tensor of shape (batch, samples)
+
+        Returns:
+            Class probabilities of shape (batch, num_classes)
+        """
+        # Apply preprocessing
+        x = self.preprocessing(x)
+
+        # Run through model
+        logits = self.model(x)
+
+        # Apply softmax for probabilities
+        if self.apply_softmax:
+            return torch.softmax(logits, dim=-1)
+        return logits
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        checkpoint_path: Union[str, Path],
+        args_path: Optional[Union[str, Path]] = None,
+        apply_softmax: bool = True,
+    ) -> 'RavenExportModel':
+        """
+        Create a RavenExportModel from a soundbay checkpoint.
+
+        Args:
+            checkpoint_path: Path to the .pth checkpoint file
+            args_path: Path to args.yaml. If None, looks for it in the same directory
+            apply_softmax: Whether to apply softmax to outputs
+
+        Returns:
+            RavenExportModel ready for export
+        """
+        checkpoint_path = Path(checkpoint_path)
+
+        # Find args.yaml
+        if args_path is None:
+            args_path = checkpoint_path.parent / 'args.yaml'
+        else:
+            args_path = Path(args_path)
+
+        if not args_path.exists():
+            raise FileNotFoundError(f"args.yaml not found at {args_path}")
+
+        # Load configuration
+        args = OmegaConf.load(args_path)
+
+        # Load checkpoint
+        checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=False)
+
+        # Create model
+        model_config = args.model.model
+        model_target = model_config._target_
+        model_class = _get_model_class(model_target)
+
+        # Get model kwargs (excluding _target_)
+        # Force pretrained=False since we're loading weights from checkpoint
+        model_kwargs = {k: v for k, v in model_config.items() if k != '_target_'}
+        model_kwargs['pretrained'] = False
+        model = model_class(**model_kwargs)
+
+        # Load weights
+        model.load_state_dict(checkpoint['model'])
+        model.eval()
+
+        # Create preprocessing pipeline
+        preprocessing = PreprocessingPipeline(
+            data_sample_rate=args.data.data_sample_rate,
+            sample_rate=args.data.sample_rate,
+            preprocessors_config=dict(args.get('_preprocessors', {})),
+        )
+
+        return cls(model=model, preprocessing=preprocessing, apply_softmax=apply_softmax)
+
+    def get_config(self, checkpoint_path: Union[str, Path]) -> dict:
+        """
+        Get configuration info needed for .ravenmodel file.
+
+        Args:
+            checkpoint_path: Path to the original checkpoint (for loading args.yaml)
+
+        Returns:
+            Dictionary with model configuration
+        """
+        checkpoint_path = Path(checkpoint_path)
+        args_path = checkpoint_path.parent / 'args.yaml'
+        args = OmegaConf.load(args_path)
+
+        return {
+            'data_sample_rate': args.data.data_sample_rate,
+            'sample_rate': args.data.sample_rate,
+            'seq_length': args.data.train_dataset.seq_length,
+            'num_classes': args.model.model.num_classes,
+            'label_names': list(args.data.label_names),
+        }


### PR DESCRIPTION
## Summary

- Adds `scripts/raven_export.py` — exports soundbay checkpoints (ResNet182D, Squeezenet2D) to Raven Intelligence `.ravenmodel` packages with preprocessing baked in
- Supports TorchScript (recommended) and ONNX export formats
- Re-implements PeakNormalize, UnitNormalize, and LibrosaPcen as `nn.Module`s for TorchScript compatibility
- Adds `--compensate-for-sigmoid` flag (recommended): Raven applies sigmoid to model outputs internally, so this option outputs `inverse_sigmoid(softmax(logits))` — Raven's sigmoid then recovers exact softmax probabilities that sum to 1.0

## Usage

**Recommended** (until Raven publishes a new version with more DOFs in their post-processing logic): compensate for Raven's sigmoid post-processing

```bash
python scripts/raven_export.py /path/to/checkpoint/best.pth \
    --output-dir ~/Raven\ Workbench/Raven\ Intelligence/Models/ \
    --name My_Detector \
    --compensate-for-sigmoid
```

**Raw logits** (no activation, Raven applies sigmoid):

```bash
python scripts/raven_export.py /path/to/checkpoint/best.pth \
    --name My_Detector --no-softmax
```

## Why some modules are re-implemented

TorchScript export requires all operations to be `nn.Module` instances or pure torch ops. Several soundbay preprocessors can't be traced as-is:

| Module | Why re-implemented | Approach |
|---|---|---|
| `PeakNormalize` | Plain class with `__call__`, not `nn.Module` — TorchScript can't trace it | Thin `nn.Module` wrapper with identical logic (verified: 0.0 diff) |
| `UnitNormalize` | Same — not `nn.Module` | Same approach (verified: 0.0 diff) |
| `LibrosaPcen` | Calls `librosa.core.pcen` (NumPy/SciPy) — can't run in TorchScript | Full reimplementation in pure PyTorch with `torch.jit.script` for the IIR loop. Matches librosa's filter coefficients and `lfilter_zi` initialization exactly |
| `MinFreqFiltering` | Uses `numpy.floor` | Replaced with `nn.Identity` (validated: only `min_freq=0` configs are supported; errors on non-zero) |

## Test plan

- [x] Exported barks detector with all 3 modes (softmax, no-softmax, compensate-for-sigmoid)
- [x] Verified compensated model scores sum to exactly 1.0 after Raven's sigmoid
- [x] Confirmed detection agreement across all export modes on real WAV file
- [x] Tested in Raven Intelligence with TH=0.2