### PR TITLE
Fix PCEN preprocessor and improve checkpoint config merging

### DIFF
--- a/soundbay/conf/augmentations/_augmentations.yaml
+++ b/soundbay/conf/augmentations/_augmentations.yaml
@@ -26,7 +26,6 @@ _augmentations:
     _target_: audiomentations.BandStopFilter
 
     min_center_freq: ${data.min_freq}
-    max_center_freq: ${data.max_freq}
     min_bandwidth_fraction: 0.05
     max_bandwidth_fraction: 0.2
     p: 0.5

--- a/soundbay/conf/augmentations/_augmentations.yaml
+++ b/soundbay/conf/augmentations/_augmentations.yaml
@@ -26,6 +26,7 @@ _augmentations:
     _target_: audiomentations.BandStopFilter
 
     min_center_freq: ${data.min_freq}
+    max_center_freq: ${data.max_freq}
     min_bandwidth_fraction: 0.05
     max_bandwidth_fraction: 0.2
     p: 0.5

--- a/soundbay/conf/preprocessors/_preprocessor_with_pcen.yaml
+++ b/soundbay/conf/preprocessors/_preprocessor_with_pcen.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+_preprocessors:
+  spectrogram:
+    _target_: torchaudio.transforms.Spectrogram
+    n_fft: ${data.n_fft}
+    hop_length: ${data.hop_length}
+  PCEN:
+      _target_: soundbay.utils.signal_processing.LibrosaPcen
+      sr: ${data.sample_rate}
+      hop_length: ${data.hop_length}
+      fmin: ${data.min_freq}
+  min_freq_filtering:
+    _target_: soundbay.data.MinFreqFiltering
+    min_freq_filtering: ${data.min_freq}
+    sample_rate: ${data.sample_rate}
+  amplitude_2_db:
+    _target_: torchaudio.transforms.AmplitudeToDB
+  peak_norm:
+    _target_: soundbay.data.PeakNormalize

--- a/soundbay/utils/checkpoint_utils.py
+++ b/soundbay/utils/checkpoint_utils.py
@@ -69,6 +69,7 @@ def merge_with_checkpoint(run_args, checkpoint_args):
     if min_freq is None:
         min_freq = checkpoint_args.data.min_freq_filtering
     run_args.data.min_freq = min_freq
+    run_args.data.max_freq = checkpoint_args.data.get('max_freq', checkpoint_args.data.sample_rate // 2)
     run_args.data.label_names = checkpoint_args.data.label_names
     OmegaConf.set_struct(run_args, True)
     return run_args

--- a/soundbay/utils/conf_validator.py
+++ b/soundbay/utils/conf_validator.py
@@ -7,7 +7,7 @@ class Dataset(BaseModel):
     num_workers: int
     sample_rate: int
     data_sample_rate: int
-    # max_freq: int
+    max_freq: Optional[int] = None
     label_type: str
     min_freq: int
     n_fft: int

--- a/soundbay/utils/signal_processing.py
+++ b/soundbay/utils/signal_processing.py
@@ -48,21 +48,24 @@ class LibrosaPcen:
          pcen: per-channel energy normalized version of signal - torch tensor
     """
 
-    def __init__(self, sr, n_mels, fmin):
+    def __init__(self, sr, hop_length=None, n_mels=None, fmin=0):
         self.sr = sr
-        self.n_mels = n_mels
-        self.slice_len = 1
-        self.hop_length = int(self.sr / (self.n_mels / self.slice_len))
+        if hop_length is not None:
+            self.hop_length = hop_length
+        elif n_mels is not None:
+            self.hop_length = int(sr / n_mels)
+        else:
+            raise ValueError("Either hop_length or n_mels must be provided")
         self.fmin = fmin
         self.fmax = sr//2
 
-    # sample,
-
     def __call__(self,  sample, gain=0.6, bias=0.1, power=0.2, time_constant=0.4, eps=1e-9):
-        hop_length = int(self.sr / (self.n_mels / self.slice_len))
-        pcen_librosa = librosa.core.pcen(sample, sr=self.sr, hop_length=self.hop_length, gain=gain, bias=bias, power=power,
-                                         time_constant=time_constant, eps=eps)
-        pcen_librosa = np.expand_dims(pcen_librosa, 0)  # expand dims to greyscale
+        if isinstance(sample, torch.Tensor):
+            sample = sample.numpy()
+        sample = np.squeeze(sample)  # remove leading singleton dims for librosa compatibility
+        pcen_librosa = librosa.pcen(sample, sr=self.sr, hop_length=self.hop_length, gain=gain, bias=bias, power=power,
+                                    time_constant=time_constant, eps=eps)
+        pcen_librosa = np.expand_dims(pcen_librosa, 0)  # add channel dim -> (1, n_freq, n_time)
 
 
         return torch.from_numpy(pcen_librosa).float()


### PR DESCRIPTION
**Summary**:
- Fix LibrosaPcen: accept hop_length param (backward compat with n_mels), handle torch.Tensor input, squeeze singleton dims to prevent 5D tensor crash, update deprecated librosa.core.pcen to librosa.pcen
- Add max_freq merging from checkpoint in merge_with_checkpoint()
- Add PCEN preprocessor config (_preprocessor_with_pcen.yaml)
- Add optional max_freq field to config validator
 

#### Context                                                                                                                                                                     
                                                                                                                                                                                
 The Amber dolphin models (echo, whistle) use a Spectrogram → PCEN preprocessor chain. These models failed on inference due to:                                                
  1. LibrosaPcen.__init__() not accepting hop_length (the param saved in their checkpoints)                                                                                   
  2. LibrosaPcen.__call__() passing a torch.Tensor to librosa.pcen (expects numpy)                                                                                              
  3. np.expand_dims adding a redundant channel dim on top of the existing one from the data pipeline, creating a 5D tensor that crashes ResNet182D.forward()                  
                                                                                                                                                                              
  All 4 Amber models (barks, echo, buzz, whistle) verified working on this branch with identical outputs to client/amber.                                                       
                                          
#### Test plan                                                                                                                                                                     
                                                                                                                                                                                
  - Barks model (4af2w6lt) — inference passes, output matches baseline                                                                                                        
  - Echo model (bki984uw) — inference passes, output matches baseline                                                                                                           
  - Buzz model (ccgojzau) — inference passes, output matches baseline                                                                                                         
  - Whistle model (g8gtuypk) — inference passes, output matches baseline                                                                                                        
  - Verify existing models (non-PCEN) still work on master (no regressions — PCEN changes are additive, n_mels param still supported)     